### PR TITLE
Fix example Configuration manifest

### DIFF
--- a/examples/configuration.yaml
+++ b/examples/configuration.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: cofiguration-aws-network
 spec:
-  package: xpkg.upbound.io/upbound/platform-aws-network:0.1.0
+  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.1.0


### PR DESCRIPTION


### Description of your changes

Fix example Configuration manifest as it had the old wrong xpkg reference

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
k apply -f examples/configuration.yaml
k get -f examples/configuration.yaml
NAME                       INSTALLED   HEALTHY   PACKAGE                                                    AGE
cofiguration-aws-network   True        True      xpkg.upbound.io/upbound/configuration-aws-network:v0.1.0   64s
```
