### PR TITLE
added securitygrouprule for accessing Elasticache/Redis

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
           BUILD_ARGS: "--load"
 
       - name: Publish Artifacts to GitHub
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         with:
           name: output
           path: _output/**

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           install: true
 
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
         with:
           submodules: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           install: true
 
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
         with:
           submodules: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
           platforms: all
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@2b51285047da1547ffb1b2203d8be4c0af6b1f20 # v3
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3
         with:
           version: ${{ env.DOCKER_BUILDX_VERSION }}
           install: true

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   e2e:
-    uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@main
+    uses: upbound/official-providers-ci/.github/workflows/pr-comment-trigger.yml@main
     with:
       package-type: configuration
     secrets:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
 
       - name: Create Tag
         uses: negz/create-tag@39bae1e0932567a58c20dea5a1a0d18358503320 # v1

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
 
       - name: Create Tag
         uses: negz/create-tag@39bae1e0932567a58c20dea5a1a0d18358503320 # v1

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: yamllint
-        uses: reviewdog/action-yamllint@81750f17598452d2e2656b7281a55788abafc205 # v1.12.0
+        uses: reviewdog/action-yamllint@8d79c3d034667db2792e328936811ed44953d691 # v1.14.0
         with:
           reporter: github-pr-review
           filter_mode: nofilter

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -5,7 +5,7 @@ jobs:
     name: runner / yamllint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
       - name: yamllint
         uses: reviewdog/action-yamllint@8d79c3d034667db2792e328936811ed44953d691 # v1.14.0
         with:

--- a/.github/workflows/yamllint.yaml
+++ b/.github/workflows/yamllint.yaml
@@ -5,7 +5,7 @@ jobs:
     name: runner / yamllint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
       - name: yamllint
         uses: reviewdog/action-yamllint@8d79c3d034667db2792e328936811ed44953d691 # v1.14.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PLATFORMS ?= linux_amd64
 # ====================================================================================
 # Setup Kubernetes tools
 
-UP_VERSION = v0.29.0
+UP_VERSION = v0.30.0
 UP_CHANNEL = stable
 UPTEST_VERSION = v0.11.1
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PLATFORMS ?= linux_amd64
 # ====================================================================================
 # Setup Kubernetes tools
 
-UP_VERSION = v0.25.0
+UP_VERSION = v0.29.0
 UP_CHANNEL = stable
 UPTEST_VERSION = v0.11.1
 

--- a/apis/basic/composition.yaml
+++ b/apis/basic/composition.yaml
@@ -531,3 +531,28 @@ spec:
                 patchSetName: network-id
               - type: PatchSet
                 patchSetName: region
+
+          - name: securityGroupRuleRedis
+            base:
+              apiVersion: ec2.aws.upbound.io/v1beta1
+              kind: SecurityGroupRule
+              spec:
+                forProvider:
+                  cidrBlocks:
+                    - 0.0.0.0/0
+                  description: Everywhere
+                  fromPort: 6379
+                  protocol: tcp
+                  securityGroupIdSelector:
+                    matchControllerRef: true
+                  toPort: 6379
+                  type: ingress
+            patches:
+              - type: PatchSet
+                patchSetName: providerConfigRef
+              - type: PatchSet
+                patchSetName: deletionPolicy
+              - type: PatchSet
+                patchSetName: network-id
+              - type: PatchSet
+                patchSetName: region

--- a/apis/basic/composition.yaml
+++ b/apis/basic/composition.yaml
@@ -532,21 +532,42 @@ spec:
               - type: PatchSet
                 patchSetName: region
 
-          - name: securityGroupRuleRedis
+          - name: securityGroupIngressRuleRedis
             base:
               apiVersion: ec2.aws.upbound.io/v1beta1
-              kind: SecurityGroupRule
+              kind: SecurityGroupIngressRule
               spec:
                 forProvider:
-                  cidrBlocks:
-                    - 0.0.0.0/0
-                  description: Everywhere
+                  cidrIpv4: "0.0.0.0/0"
+                  description: "Redis Access From Everywhere"
                   fromPort: 6379
-                  protocol: tcp
+                  ipProtocol: "tcp"
                   securityGroupIdSelector:
                     matchControllerRef: true
                   toPort: 6379
-                  type: ingress
+            patches:
+              - type: PatchSet
+                patchSetName: providerConfigRef
+              - type: PatchSet
+                patchSetName: deletionPolicy
+              - type: PatchSet
+                patchSetName: network-id
+              - type: PatchSet
+                patchSetName: region
+
+          - name: securityGroupIngressRuleMemcached
+            base:
+              apiVersion: ec2.aws.upbound.io/v1beta1
+              kind: SecurityGroupIngressRule
+              spec:
+                forProvider:
+                  cidrIpv4: "0.0.0.0/0"
+                  description: "Memcached Access From Everywhere"
+                  fromPort: 11211
+                  ipProtocol: "tcp"
+                  securityGroupIdSelector:
+                    matchControllerRef: true
+                  toPort: 11211
             patches:
               - type: PatchSet
                 patchSetName: providerConfigRef

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -18,7 +18,7 @@ spec:
   dependsOn:
     - provider: xpkg.upbound.io/upbound/provider-aws-ec2
       # renovate: datasource=github-releases depName=upbound/provider-aws
-      version: "v1.2.0"
+      version: "v1.4.0"
     - function: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform
       # renovate: datasource=github-releases depName=crossplane-contrib/function-patch-and-transform
       version: "v0.4.0"

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -21,4 +21,4 @@ spec:
       version: "v1.4.0"
     - function: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform
       # renovate: datasource=github-releases depName=crossplane-contrib/function-patch-and-transform
-      version: "v0.4.0"
+      version: "v0.5.0"

--- a/examples/configuration.yaml
+++ b/examples/configuration.yaml
@@ -1,6 +1,6 @@
 apiVersion: pkg.crossplane.io/v1
 kind: Configuration
 metadata:
-  name: cofiguration-aws-network
+  name: configuration-aws-network
 spec:
-  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.1.0
+  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.1.2

--- a/examples/configuration.yaml
+++ b/examples/configuration.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: configuration-aws-network
 spec:
-  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.1.2
+  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.12.0

--- a/examples/configuration.yaml
+++ b/examples/configuration.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: configuration-aws-network
 spec:
-  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.12.0
+  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.13.0

--- a/examples/configuration.yaml
+++ b/examples/configuration.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: configuration-aws-network
 spec:
-  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.1.2
+  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.1.3

--- a/examples/configuration.yaml
+++ b/examples/configuration.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: configuration-aws-network
 spec:
-  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.1.3
+  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.1.2

--- a/examples/function/function.yaml
+++ b/examples/function/function.yaml
@@ -3,4 +3,4 @@ kind: Function
 metadata:
   name: crossplane-contrib-function-patch-and-transform
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.2.1
+  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.4.0


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Added securitygrouprule for accessing Elasticache/Redis, so that this configuration can be used by a forthcoming configuration-aws-elasticache reference.

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
make e2e