### PR TITLE
Switch to crossplane build module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build"]
 	path = build
-	url = https://github.com/upbound/build
+	url = https://github.com/crossplane/build

--- a/examples/configuration.yaml
+++ b/examples/configuration.yaml
@@ -3,4 +3,4 @@ kind: Configuration
 metadata:
   name: cofiguration-aws-network
 spec:
-  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.1.0
+  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.15.0


### PR DESCRIPTION
* Upbound build module was deprecated so switch to the new crossplane
  one
* Inline Configuration example version bump

Signed-off-by: Yury Tsarev <yury@upbound.io>
