### PR TITLE
Make uptest slightly more user friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The core components of a custom API in [Crossplane](https://docs.crossplane.io/l
 In this specific configuration, the AWS Network API contains:
 
 - **an [AWS network](/apis/definition.yaml) custom resource type.**
-- **Composition of the networking resources:** Configured in [/apis/basic/composition.yaml](/apis/basic/composition.yaml), it provisions networking resources in the `upbound-system` namespace.
+- **Composition of the networking resources:** Configured in [/apis/composition.yaml](/apis/composition.yaml), it provisions networking resources in the `upbound-system` namespace.
 
 This repository contains an Composite Resource (XR) file.
 
@@ -25,7 +25,20 @@ kind: Configuration
 metadata:
   name: configuration-aws-network
 spec:
-  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.10.0
+  package: xpkg.upbound.io/upbound/configuration-aws-network:v0.15.0
+```
+
+## Testing
+
+Run `make help.local` to get the up-to-date documentation for the testing
+related targets, e.g
+
+```shell
+make help.local
+e2e                            Run uptest together with all dependencies. Use `make e2e SKIP_DELETE=--skip-delete` to skip deletion of resources.
+render                         Crossplane render
+submodules                     Update the submodules, such as the common build scripts.
+yamllint                       Static yamllint check
 ```
 
 ## Next steps


### PR DESCRIPTION
### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

* Add SKIP_DELETE
* Fail fast if UPTEST_CLOUD_CREDENTIALS are not set
```
make e2e
23:56:37 [ .. ] Please export UPTEST_CLOUD_CREDENTIALS, e.g. `export UPTEST_CLOUD_CREDENTIALS=(cat ~/.aws/credentials)`
23:56:37 [FAIL]
make: *** [Makefile:67: check] Error 1
```
* Self-document user facing make targets and create `help.local`
```
make help.local
e2e                            Run uptest together with all dependencies. Use `make e2e SKIP_DELETE=--skip-delete` to skip deletion of resources.
render                         Crossplane render
submodules                     Update the submodules, such as the common build scripts.
yamllint                       Static yamllint check
```
* Remove outdated info on deletion hook requirement

<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->


I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

By running make targets
