### PR TITLE
fix(xr): fix status null, adopt structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,35 @@ This repository serves as a foundational step. To enhance your control plane, co
 
 
 Upbound will automatically detect the commits you make in your repo and build the configuration package for you. To learn more about how to build APIs for your managed control planes in Upbound, read the guide on Upbound's docs.
+
+# Using the make file
+## render target
+### Overview
+`make render` target automates the rendering of Crossplane manifests using specified annotations within your YAML files.
+The annotations guide the rendering process, specifying paths to composition, function, environment, and observe files.
+
+### Annotations
+The `make render` target relies on specific annotations in your YAML files to determine how to process each file.
+The following annotations are supported:
+
+**render.crossplane.io/composition-path**: Specifies the path to the composition file to be used in rendering.
+
+**render.crossplane.io/function-path**: Specifies the path to the function file to be used in rendering.
+
+**render.crossplane.io/environment-path** (optional): Specifies the path to the environment file. If not provided, the rendering will proceed without an environment.
+
+**render.crossplane.io/observe-path** (optional): Specifies the path to the observe file. If not provided, the rendering will proceed without observation settings.
+
+```yaml
+apiVersion: aws.platform.upbound.io/v1alpha1
+kind: XNetwork
+metadata:
+  name: configuration-aws-network
+  annotations:
+    render.crossplane.io/composition-path: apis/gotpl/composition.yaml
+    render.crossplane.io/function-path: examples/functions.yaml
+spec:
+  parameters:
+    id: configuration-aws-network
+    region: us-west-2
+```

--- a/apis/gotpl/composition.yaml
+++ b/apis/gotpl/composition.yaml
@@ -4,13 +4,14 @@ metadata:
   name: xnetworks.aws.platform.upbound.io
   labels:
     provider: aws
+    function: go-templating
 spec:
   compositeTypeRef:
     apiVersion: aws.platform.upbound.io/v1alpha1
     kind: XNetwork
   mode: Pipeline
   pipeline:
-    - step: render-templates
+    - step: go-templating
       functionRef:
         name: crossplane-contrib-function-go-templating
       input:
@@ -246,25 +247,62 @@ spec:
             apiVersion: {{ .observed.composite.resource.apiVersion }}
             kind: {{ .observed.composite.resource.kind }}
             status:
-              vpcId: {{ dig "resources" "vpc" "resource" "status" "atProvider" "id" "" $.observed }}
+              {{- $vpcId := dig "resources" "vpc" "resource" "status" "atProvider" "id" "" $.observed }}
+              {{- if $vpcId }}
+              vpcId: {{ $vpcId }}
+              {{- end }}
+
+              {{- $subnetIds := list }}
+              {{- range $i, $subnet := $params.subnets }}
+              {{- $subnetId := dig "resources" (printf "subnet-%s-%s" $subnet.availabilityZone $subnet.type) "resource" "metadata" "annotations" "crossplane.io/external-name" "" $.observed }}
+              {{- if $subnetId }}
+              {{- $subnetIds = append $subnetIds $subnetId }}
+              {{- end }}
+              {{- end }}
+              {{- if $subnetIds }}
               subnetIds:
-                {{- range $i, $subnet := $params.subnets }}
-                - {{ dig "resources" (printf "subnet-%s-%s" $subnet.availabilityZone $subnet.type) "resource" "metadata" "annotations" "crossplane.io/external-name" "" $.observed }}
+                {{- range $id := $subnetIds }}
+                - {{ $id }}
                 {{- end }}
+              {{- end }}
+
+              {{- $publicSubnetIds := list }}
+              {{- range $i, $subnet := $params.subnets }}
+              {{- if eq $subnet.type "public" }}
+              {{- $publicSubnetId := dig "resources" (printf "subnet-%s-%s" $subnet.availabilityZone $subnet.type) "resource" "metadata" "annotations" "crossplane.io/external-name" "" $.observed }}
+              {{- if $publicSubnetId }}
+              {{- $publicSubnetIds = append $publicSubnetIds $publicSubnetId }}
+              {{- end }}
+              {{- end }}
+              {{- end }}
+              {{- if $publicSubnetIds }}
               publicSubnetIds:
-                {{- range $i, $subnet := $params.subnets }}
-                {{- if eq $subnet.type "public" }}
-                - {{ dig "resources" (printf "subnet-%s-%s" $subnet.availabilityZone $subnet.type) "resource" "metadata" "annotations" "crossplane.io/external-name" "" $.observed }}
+                {{- range $id := $publicSubnetIds }}
+                - {{ $id }}
                 {{- end }}
-                {{- end }}
+              {{- end }}
+
+              {{- $privateSubnetIds := list }}
+              {{- range $i, $subnet := $params.subnets }}
+              {{- if eq $subnet.type "private" }}
+              {{- $privateSubnetId := dig "resources" (printf "subnet-%s-%s" $subnet.availabilityZone $subnet.type) "resource" "metadata" "annotations" "crossplane.io/external-name" "" $.observed }}
+              {{- if $privateSubnetId }}
+              {{- $privateSubnetIds = append $privateSubnetIds $privateSubnetId }}
+              {{- end }}
+              {{- end }}
+              {{- end }}
+              {{- if $privateSubnetIds }}
               privateSubnetIds:
-                {{- range $i, $subnet := $params.subnets }}
-                {{- if eq $subnet.type "private" }}
-                - {{ dig "resources" (printf "subnet-%s-%s" $subnet.availabilityZone $subnet.type) "resource" "metadata" "annotations" "crossplane.io/external-name" "" $.observed }}
+                {{- range $id := $privateSubnetIds }}
+                - {{ $id }}
                 {{- end }}
-                {{- end }}
+              {{- end }}
+
+              {{- $sgId := dig "resources" "sg" "resource" "metadata" "annotations" "crossplane.io/external-name" "" $.observed }}
+              {{- if $sgId }}
               securityGroupIds:
-                - {{ dig "resources" "sg" "resource" "metadata" "annotations" "crossplane.io/external-name" "" $.observed }}
+                - {{ $sgId }}
+              {{- end }}
     - step: automatically-detect-ready-composed-resources
       functionRef:
         name: crossplane-contrib-function-auto-ready

--- a/examples/gotpl/network-xr.yaml
+++ b/examples/gotpl/network-xr.yaml
@@ -1,10 +1,13 @@
 apiVersion: aws.platform.upbound.io/v1alpha1
 kind: XNetwork
 metadata:
-  name: ref-aws-network
+  name: configuration-aws-network
+  annotations:
+    render.crossplane.io/composition-path: apis/gotpl/composition.yaml
+    render.crossplane.io/function-path: examples/functions.yaml
 spec:
   parameters:
-    id: platform-ref-aws
+    id: configuration-aws-network
     region: us-west-2
     vpcCidrBlock: 192.168.0.0/16
     subnets:


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
- bump submodule
- fix xr status null with condition
- adopt makefile 
- new structure in folders apis/ and examples/

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #80

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
--- PASS: kuttl (247.38s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/case (247.16s)
PASS
14:45:31 [ OK ] running automated tests
```


```
[...]
Status:
  Conditions:
    Last Transition Time:  2024-08-16T12:42:03Z
    Reason:                ReconcileSuccess
    Status:                True
    Type:                  Synced
    Last Transition Time:  2024-08-16T12:43:59Z
    Message:               Unready resources: route, rta-us-west-2a-private, rta-us-west-2a-public, and 2 more
    Reason:                Creating
    Status:                False
    Type:                  Ready
  Private Subnet Ids:
    subnet-0ce436b7965068d96
    subnet-07e6e02fdb3cbe976
  Public Subnet Ids:
    subnet-03e169a73387e48fe
    subnet-0e2e7161ba116a55a
  Security Group Ids:
    sg-0b0db19069c59ffce
  Subnet Ids:
    subnet-03e169a73387e48fe
    subnet-0e2e7161ba116a55a
    subnet-0ce436b7965068d96
    subnet-07e6e02fdb3cbe976
  Vpc Id:  vpc-0a1e5c8546358535a
Events:
  Type    Reason             Age                     From                                                             Message
  ----    ------             ----                    ----                                                             -------
  Normal  SelectComposition  2m16s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Successfully selected composition: xnetworks.aws.platform.upbound.io
  Normal  SelectComposition  2m16s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Selected composition revision: xnetworks.aws.platform.upbound.io-f7b4635
  Normal  ComposeResources   2m14s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Successfully composed resources
  Normal  ComposeResources   2m14s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "subnet-us-west-2a-public" is not yet ready
  Normal  ComposeResources   2m14s (x2 over 2m14s)   defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "rta-us-west-2b-private" is not yet ready
  Normal  ComposeResources   2m14s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "subnet-us-west-2b-public" is not yet ready
  Normal  ComposeResources   2m14s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "subnet-us-west-2a-private" is not yet ready
  Normal  ComposeResources   2m14s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "rt" is not yet ready
  Normal  ComposeResources   2m14s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "subnet-us-west-2b-private" is not yet ready
  Normal  ComposeResources   2m14s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "sgrp" is not yet ready
  Normal  ComposeResources   2m14s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "rta-us-west-2a-private" is not yet ready
  Normal  ComposeResources   2m14s (x12 over 2m14s)  defined/compositeresourcedefinition.apiextensions.crossplane.io  (combined from similar events): Composed resource "rta-us-west-2b-public" is not yet ready
  Normal  ComposeResources   2m14s (x11 over 2m14s)  defined/compositeresourcedefinition.apiextensions.crossplane.io  (combined from similar events): Composed resource "sgrm" is not yet ready
  Normal  ComposeResources   2m14s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "vpc" is not yet ready
  Normal  ComposeResources   2m14s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "rta-us-west-2b-public" is not yet ready
  Normal  ComposeResources   2m14s                   defined/compositeresourcedefinition.apiextensions.crossplane.io  Composed resource "sgrm" is not yet ready

```
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
