### PR TITLE
Switch to v1 provider tag

### DIFF
--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -17,8 +17,7 @@ spec:
     version: ">=v1.14.1-0"
   dependsOn:
     - provider: xpkg.upbound.io/upbound/provider-aws-ec2
-      # renovate: datasource=github-releases depName=upbound/provider-aws
-      version: "v1.19.0"
+      version: "v1"
     - function: xpkg.upbound.io/crossplane-contrib/function-auto-ready
       # renovate: datasource=github-releases depName=crossplane-contrib/function-auto-ready
       version: "v0.4.0"


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Switch to v1 tag according to upcoming changes described in https://blog.upbound.io/upbound-official-packages-changes
* Disable renovate for provider version tag as it is going to be stable

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

uptest below
