### PR TITLE
Allow up-token for e2e to differ from deployment token

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,8 +10,10 @@ on:
       - labeled
 
 env:
-  UP_API_TOKEN: ${{ secrets.UP_API_TOKEN }}
-  UP_ORG: ${{ secrets.UP_ORG }}
+  UP_API_TOKEN: ${{ secrets.UP_E2E_API_TOKEN || secrets.UP_API_TOKEN }}
+  UP_ORG: ${{ secrets.UP_E2E_ORG || secrets.UP_ORG }}
+  UP_GROUP: ${{ secrets.UP_E2E_GROUP || secrets.UP_GROUP || "default" }}
+  UP_ROBOT_ID: ${{ secrets.UP_E2E_ROBOT_ID || secrets.UP_ROBOT_ID }}
 
 jobs:
   e2e:
@@ -26,14 +28,22 @@ jobs:
         if: env.UP_API_TOKEN != '' && env.UP_ORG != ''
         uses: upbound/action-up@v1
         with:
-          api-token: ${{ secrets.UP_API_TOKEN }}
-          organization: ${{ secrets.UP_ORG }}
+          api-token: ${{ env.UP_API_TOKEN }}
+          organization: ${{ env.UP_ORG }}
+
+      # doesn't work with plain token when pushing otherwise
+      - name: Login to xpkg with robot
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: xpkg.upbound.io
+          username: ${{ env.UP_ROBOT_ID }}
+          password: ${{ env.UP_API_TOKEN }}
 
       - name: Build project
         run: up project build
 
       - name: Switch up context
-        run: up ctx ${{ secrets.UP_ORG }}/upbound-gcp-us-central-1/default
+        run: up ctx ${{ env.UP_ORG }}/upbound-gcp-us-central-1/${{ env.UP_GROUP }}
 
       - name: Download and install Upbound-enhanced Chainsaw(remove me later)
         run: |


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

This will give us the ability to use a robot token in e2e tests which differs from the main token which we use for deploying the package. 

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->


I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
