### PR TITLE
feat(mrap): adding mrap, use mrap for e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ In this specific configuration, the AWS Network API contains:
 - Alternatively, install the Configuration from the [Upbound Marketplace](https://marketplace.upbound.io/configurations/upbound/configuration-aws-network)
 - Check [examples](/examples/) for example XR(Composite Resource)
 
+## Managed Resource Activation Policy
+
+This configuration includes a `ManagedResourceActivationPolicy` (MRAP) that enables only the required CRDs from dependent providers. If you're running Crossplane without a default activation policy, this ensures that only the necessary CRDs are activated, reducing resource overhead and improving control plane performance.
+
+To view the MRAP:
+```bash
+kubectl get managedresourceactivationpolicy configuration-aws-network -o yaml
+```
+
 ## Testing
 
 The configuration can be tested using:

--- a/apis/networks/mrap.yaml
+++ b/apis/networks/mrap.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.crossplane.io/v1alpha1
+kind: ManagedResourceActivationPolicy
+metadata:
+  name: configuration-aws-network
+spec:
+  activate:
+  - internetgateways.ec2.aws.m.upbound.io
+  - mainroutetableassociations.ec2.aws.m.upbound.io
+  - routes.ec2.aws.m.upbound.io
+  - routetableassociations.ec2.aws.m.upbound.io
+  - routetables.ec2.aws.m.upbound.io
+  - securitygrouprules.ec2.aws.m.upbound.io
+  - securitygroups.ec2.aws.m.upbound.io
+  - subnets.ec2.aws.m.upbound.io
+  - vpcs.ec2.aws.m.upbound.io

--- a/tests/e2etest-network/main.k
+++ b/tests/e2etest-network/main.k
@@ -1,15 +1,29 @@
 import models.io.upbound.awsm.v1beta1 as awsv1beta1
 import models.io.upbound.dev.meta.v1alpha1 as metav1alpha1
 import models.io.upbound.platform.aws.v1alpha1 as platformawsv1alpha1
-
+import models.io.crossplane.apiextensions.v1alpha1 as apiextensionsv1alpha1
 
 _items = [
     metav1alpha1.E2ETest{
         metadata.name: "e2e-test-network"
         spec= {
             crossplane.autoUpgrade.channel: "None"
-            crossplane.version = "2.0.2-up.5"
+            crossplane.version = "2.1.4-up.2"
             defaultConditions: ["Ready"]
+            initResources: [
+                # Disable default managedResourceActivationPolicy to enable only
+                # required CRDs via MRAP
+                apiextensionsv1alpha1.ManagedResourceActivationPolicy{
+                    metadata = {
+                        name = "default"
+                    }
+                    spec = {
+                        activate: [
+                            ""
+                        ]
+                    }
+                }
+            ]
             manifests: [
                 platformawsv1alpha1.Network{
                     metadata = {

--- a/upbound.yaml
+++ b/upbound.yaml
@@ -3,6 +3,10 @@ kind: Project
 metadata:
   name: configuration-aws-network
 spec:
+  apiDependencies:
+  - http:
+      url: https://raw.githubusercontent.com/crossplane/crossplane/refs/tags/v2.1.4/cluster/crds/apiextensions.crossplane.io_managedresourceactivationpolicies.yaml
+    type: crd
   dependsOn:
   - apiVersion: pkg.crossplane.io/v1
     kind: Provider


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes
- adding mrap and package with configuration package
- disable the default mrap * in e2e test controlplane

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
  ✓   Finding test resources
Cleanup summary: 0 deleted, 0 remaining after 0 attempts
Tearing down test control plane...

Test control plane deleted

SUCCESS: 
SUCCESS: Tests Summary:
SUCCESS: ------------------
SUCCESS: Total Tests Executed: 1
SUCCESS: Passed tests:         1
SUCCESS: Failed tests:         0
```

```
kubectl get crds | grep "aws.m.upbound.io"         
clusterproviderconfigs.aws.m.upbound.io                         2026-02-08T21:06:43Z
internetgateways.ec2.aws.m.upbound.io                           2026-02-08T21:06:50Z
mainroutetableassociations.ec2.aws.m.upbound.io                 2026-02-08T21:06:50Z
providerconfigs.aws.m.upbound.io                                2026-02-08T21:06:43Z
providerconfigusages.aws.m.upbound.io                           2026-02-08T21:06:43Z
routes.ec2.aws.m.upbound.io                                     2026-02-08T21:06:52Z
routetableassociations.ec2.aws.m.upbound.io                     2026-02-08T21:06:51Z
routetables.ec2.aws.m.upbound.io                                2026-02-08T21:06:51Z
securitygrouprules.ec2.aws.m.upbound.io                         2026-02-08T21:06:51Z
securitygroups.ec2.aws.m.upbound.io                             2026-02-08T21:06:51Z
subnets.ec2.aws.m.upbound.io                                    2026-02-08T21:06:54Z
vpcs.ec2.aws.m.upbound.io                                       2026-02-08T21:06:54Z
```

```
kubectl get ManagedResourceActivationPolicy -o yaml
apiVersion: v1
items:
- apiVersion: apiextensions.crossplane.io/v1alpha1
  kind: ManagedResourceActivationPolicy
  metadata:
    creationTimestamp: "2026-02-08T21:06:43Z"
    generation: 1
    name: configuration-aws-network
    ownerReferences:
    - apiVersion: pkg.crossplane.io/v1
      blockOwnerDeletion: true
      controller: true
      kind: ConfigurationRevision
      name: configuration-aws-network-944209d843c8
      uid: 22884aea-2e0f-4482-a5c1-a780ea0b4314
    - apiVersion: pkg.crossplane.io/v1
      blockOwnerDeletion: true
      controller: false
      kind: Configuration
      name: configuration-aws-network
      uid: 14e8db91-39c8-45c7-8672-369185db0636
    resourceVersion: "1671"
    uid: 0f707ac3-ac59-4d58-a5f0-2dc2b6235bb0
  spec:
    activate:
    - internetgateways.ec2.aws.m.upbound.io
    - mainroutetableassociations.ec2.aws.m.upbound.io
    - routes.ec2.aws.m.upbound.io
    - routetableassociations.ec2.aws.m.upbound.io
    - routetables.ec2.aws.m.upbound.io
    - securitygrouprules.ec2.aws.m.upbound.io
    - securitygroups.ec2.aws.m.upbound.io
    - subnets.ec2.aws.m.upbound.io
    - vpcs.ec2.aws.m.upbound.io
  status:
    activated:
    - internetgateways.ec2.aws.m.upbound.io
    - mainroutetableassociations.ec2.aws.m.upbound.io
    - routes.ec2.aws.m.upbound.io
    - routetableassociations.ec2.aws.m.upbound.io
    - routetables.ec2.aws.m.upbound.io
    - securitygrouprules.ec2.aws.m.upbound.io
    - securitygroups.ec2.aws.m.upbound.io
    - subnets.ec2.aws.m.upbound.io
    - vpcs.ec2.aws.m.upbound.io
    conditions:
    - lastTransitionTime: "2026-02-08T21:06:44Z"
      observedGeneration: 1
      reason: Running
      status: "True"
      type: Healthy
- apiVersion: apiextensions.crossplane.io/v1alpha1
  kind: ManagedResourceActivationPolicy
  metadata:
    creationTimestamp: "2026-02-08T21:04:26Z"
    generation: 2
    name: default
    resourceVersion: "857"
    uid: f5bc5368-4c54-4f02-b7f3-5bd9a3c4fc7b
  spec:
    activate:
    - ""
  status:
    conditions:
    - lastTransitionTime: "2026-02-08T21:06:13Z"
      observedGeneration: 2
      reason: Running
      status: "True"
      type: Healthy
kind: List
metadata:
  resourceVersion: ""
```


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->
